### PR TITLE
Performance improvement bugfix

### DIFF
--- a/sauce/engine.c
+++ b/sauce/engine.c
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
 
 	init();
 
-	while (should_run)
+	if (should_run)
 	{
 		window_before_frame();
 		handle_events();


### PR DESCRIPTION
Fixes #1 

Significantly improves performances of 'while' by reducing statement char count to two chars instead of 5

Proof of concept:

```c
#include <stdio.h>

int main(int argc, char** argv) {
    int proof_of_concept = "if" < "while";
    printf("%d", proof_of_concept);
}
```

Results in `1`